### PR TITLE
updated PIL compatibility for ImageFont.draw

### DIFF
--- a/examples/logo_pixelhouse_animated.py
+++ b/examples/logo_pixelhouse_animated.py
@@ -9,6 +9,8 @@ def logo_animation(logo_text):
 
     lg = ph.gradient.linear([pal[0], pal[1]], theta=-np.pi / 4)
 
+    A += ph.rectangle(-400, -400, 400, 400, color=pal[-1])
+    
     A += ph.circle(color=pal[3])
     A += ph.filters.gaussian_blur()
     A += ph.circle(color=pal[3])

--- a/pixelhouse/primitives.py
+++ b/pixelhouse/primitives.py
@@ -312,9 +312,7 @@ class text(PrimitiveArtist):
         font = ImageFont.truetype(self.font(t), fs)
 
         # Measure the font
-        bb = font.getbbox(text)
-        tw = bb[2]
-        th = bb[3]
+        _, _, tw, th = font.getbbox(text)
 
         vpos = self.vpos(t)
         if vpos == "upper":

--- a/pixelhouse/primitives.py
+++ b/pixelhouse/primitives.py
@@ -312,7 +312,9 @@ class text(PrimitiveArtist):
         font = ImageFont.truetype(self.font(t), fs)
 
         # Measure the font
-        tw, th = font.getsize(text)
+        bb = font.getbbox(text)
+        tw = bb[2]
+        th = bb[3]
 
         vpos = self.vpos(t)
         if vpos == "upper":


### PR DESCRIPTION
ImageFont.getsize deprecated, replacement is ImageFont.getbbox with slightly different syntax